### PR TITLE
choose-file: Now supports executing command directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Portions of this code from [Porting Eval to Go](https://thorstenball.com/blog/20
 
 This subcommand presents a console-based UI to select a file.  The file selected will be displayed upon STDOUT.  The list may be filtered via an input-field.  (Use TAB to switch focus between the filter-field and list.)
 
-Useful for launching videos, etc.  (`xine "$(sysbox choose-file ~/Videos)"`)
+Useful for launching videos, etc.  (`sysbox choose-file -execute="xine {}" ~/Videos`)
 
 
 ## chronic

--- a/README.md
+++ b/README.md
@@ -82,9 +82,16 @@ Portions of this code from [Porting Eval to Go](https://thorstenball.com/blog/20
 
 ## choose-file
 
-This subcommand presents a console-based UI to select a file.  The file selected will be displayed upon STDOUT.  The list may be filtered via an input-field.  (Use TAB to switch focus between the filter-field and list.)
+This subcommand presents a console-based UI to select a file.  The file selected will be displayed upon STDOUT.  The list may be filtered via an input-field.
 
-Useful for launching videos, etc.  (`sysbox choose-file -execute="xine {}" ~/Videos`)
+Useful for launching videos, emulators, etc:
+
+* `sysbox choose-file -execute="xine -g --no-logo --no-splash -V=40 {}" ~/Videos`
+  * Choose a file, and execute `xine` with that filename as one of the arguments.
+* `xine $(sysbox choose-file ~/Videos)`
+  * Use the STDOUT result to launch instead.
+
+The first form is preferred, because if the selection is canceled nothing happens.  In the second-case `xine` would be launched with no argument.
 
 
 ## chronic

--- a/cmd_choose_file.go
+++ b/cmd_choose_file.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,6 +15,9 @@ import (
 // Structure for our options and state.
 type chooseFileCommand struct {
 
+	// Command to execute
+	exec string
+
 	// Filenames we'll let the user choose between
 	files []string
 
@@ -23,6 +27,7 @@ type chooseFileCommand struct {
 
 // Arguments adds per-command args to the object.
 func (cf *chooseFileCommand) Arguments(f *flag.FlagSet) {
+	f.StringVar(&cf.exec, "execute", "", "Command to execute once a selection has been made")
 }
 
 // Info returns the name of this subcommand.
@@ -185,7 +190,55 @@ func (cf *chooseFileCommand) Execute(args []string) int {
 		panic(err)
 	}
 
+	//
+	// Did something get chosen?
+	//
 	if cf.chosen != "" {
+
+		//
+		// Are we executing?
+		//
+		if cf.exec != "" {
+
+			//
+			// Split into command and arguments
+			//
+			pieces := strings.Fields(cf.exec)
+
+			//
+			// Expand the args - this is horrid
+			//
+			// Is a hack to ensure that things work if we
+			// have a selected filename with spaces inside it.
+			//
+			toRun := []string{}
+
+			for _, piece := range pieces {
+				piece = strings.ReplaceAll(piece, "{}", cf.chosen)
+				toRun = append(toRun, piece)
+			}
+
+			//
+			// Run it.
+			//
+			cmd := exec.Command(toRun[0], toRun[1:]...)
+			out, errr := cmd.CombinedOutput()
+			if errr != nil {
+				fmt.Printf("Error running '%s': %s\n", cf.exec, errr.Error())
+				return 1
+			}
+
+			//
+			// Show the output
+			//
+			fmt.Printf("%s", out)
+
+			//
+			// Otherwise we're done
+			//
+			return 0
+
+		}
 		fmt.Printf("%s\n", cf.chosen)
 		return 0
 	}


### PR DESCRIPTION
Example:

```
./sysbox choose-file -execute "xine {}" ~/Videos/
```

This works with filenames containing spaces, but it could be improved
and the exec-stuff should be moved to a common-library in the future.

This closes #3.