### PR TITLE
Added `version` sub-command.

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -33,6 +33,6 @@ for OS in ${BUILD_PLATFORMS[@]}; do
         export CGO_ENABLED=0
 
         # Build the main-binary
-        go build -ldflags "-X main.version=$(git describe --tags 2>/dev/null || echo 'master')" -o "${BASE}-${SUFFIX}"
+        go build -ldflags "-X main.versionString=$(git describe --tags 2>/dev/null || echo 'master')" -o "${BASE}-${SUFFIX}"
     done
 done

--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ Validate JSON files for correctness and syntax-errors.
 Validate XML files for correctness and syntax-errors.
 
 
+## version
+
+Report the version of the binary, when downloaded from our [release page](https://github.com/skx/sysbox/releases).
+
+
 ## validate-yaml
 
 Validate YAML files for correctness and syntax-errors.

--- a/cmd_version.go
+++ b/cmd_version.go
@@ -1,0 +1,42 @@
+package main
+
+//go:generate echo Hello, Go Generate!
+import (
+	"fmt"
+
+	"github.com/skx/subcommands"
+)
+
+var (
+	versionString = "unreleased"
+)
+
+// Structure for our options and state.
+type versionCommand struct {
+
+	// We embed the NoFlags option, because we accept no command-line flags.
+	subcommands.NoFlags
+}
+
+// Info returns the name of this subcommand.
+func (t *versionCommand) Info() (string, string) {
+	return "version", `Show the version of the binary.
+
+Details:
+
+This reports upon the version of the sysbox application.
+
+Usage:
+
+   $ sysbox version
+
+`
+}
+
+// Execute is invoked if the user specifies `version` as the subcommand.
+func (t *versionCommand) Execute(args []string) int {
+
+	fmt.Printf("%s\n", versionString)
+
+	return 0
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 	subcommands.Register(&validateJSONCommand{})
 	subcommands.Register(&validateXMLCommand{})
 	subcommands.Register(&validateYAMLCommand{})
+	subcommands.Register(&versionCommand{})
 	subcommands.Register(&withLockCommand{})
 
 	//


### PR DESCRIPTION
This reports "unreleased" when built from the git-repository, but
will report the tag/release information when autogenerated releases
are built via the github-action.

This closes #37.