### PR TITLE
Allow running commands when peers come/go

### DIFF
--- a/cmd_peerd.go
+++ b/cmd_peerd.go
@@ -182,7 +182,16 @@ Now launch on the a second host, giving the IP of at least one peer:
 Both hosts will know about the other, and will update their local state
 file if the other host goes away, or new hosts join.
 
-Firewalling:
+
+Notifications:
+
+You can configure a (shell) command to execute when peers join, or leave,
+the peer network via '-run-up' and '-run-down'.  Within those commands
+$IP and $NAME will be expanded to contain the appropriate detail of the
+remote peer which has joined/left the group.
+
+
+Firewalling considerations:
 
 The communication happens over port 7946.`
 }


### PR DESCRIPTION
We allow running a shell-command when a peer comes or goes from the group, and support expanding parameters in those shelp commands:

$NAME/${NAME} is the name of the node.
$IP/${IP} is the IP of the node.

Sample usage:

     sysbox peerd -run-up 'touch /tmp/$NAME.$IP'

Then:

      ls /tmp/fr*
      /tmp/frodo.home.192.168.1.101

This closes #44.